### PR TITLE
Improve bouncer acceptance slack

### DIFF
--- a/bouncer.py
+++ b/bouncer.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import math
+import random
 from typing import Dict, List, Optional, Tuple
 
 class BerghainBouncer:
@@ -43,49 +44,40 @@ class BerghainBouncer:
         remaining_capacity = 1000 - admitted_count
         if remaining_capacity <= 0:
             return 0.0
-            
-        correlations = attribute_stats.get("correlations", {})
-        frequencies = attribute_stats["relativeFrequencies"]
-        
-        total_value = 0.0
-        constraint_satisfaction = 0.0
-        
-        for constraint in constraints:
-            attr = constraint["attribute"]
-            min_count = constraint["minCount"]
-            current_count = current_counts.get(attr, 0)
-            remaining_needed = max(0, min_count - current_count)
-            
-            if person_attributes.get(attr, False):
-                constraint_satisfaction += 1
-                
-                if remaining_needed > 0:
-                    attr_frequency = frequencies[attr]
-                    expected_future_with_attr = remaining_capacity * attr_frequency
-                    
-                    urgency = remaining_needed / max(1, expected_future_with_attr)
-                    
-                    correlation_bonus = 0.0
-                    for other_attr, has_other in person_attributes.items():
-                        if has_other and other_attr != attr and other_attr in correlations.get(attr, {}):
-                            correlation_value = correlations[attr][other_attr]
-                            if correlation_value > 0:
-                                correlation_bonus += correlation_value * 0.1
-                    
-                    total_value += urgency * (1 + correlation_bonus)
-        
-        progress_ratio = admitted_count / 1000.0
-        if progress_ratio < 0.3:
-            threshold_modifier = 0.8
-        elif progress_ratio < 0.7:
-            threshold_modifier = 1.0
-        else:
-            threshold_modifier = 1.2
-            
-        if constraint_satisfaction > 0:
-            return min(1.0, (total_value / constraint_satisfaction) * threshold_modifier)
-        else:
-            return 0.1
+
+        # If all constraints are already satisfied, admit everyone else to avoid
+        # unnecessary rejections and fill the club efficiently.
+        shortages = {
+            c["attribute"]: max(0, c["minCount"] - current_counts.get(c["attribute"], 0))
+            for c in constraints
+        }
+
+        if all(v == 0 for v in shortages.values()):
+            return 1.0
+
+        # Accept anyone who contributes to an unmet constraint
+        for attr, shortage in shortages.items():
+            if shortage > 0 and person_attributes.get(attr, False):
+                return 1.0
+
+        # Person doesn't help meet unmet constraints; decide based on expected availability
+        remaining_capacity_after = remaining_capacity - 1
+        if remaining_capacity_after <= 0:
+            return 0.0
+
+        freq = attribute_stats.get("relativeFrequencies", {})
+        required_draws = 0.0
+        for attr, shortage in shortages.items():
+            p = freq.get(attr, 0.01)
+            required_draws = max(required_draws, shortage / p)
+
+        buffer = 15  # keep some spare capacity beyond expected needs
+        slack = remaining_capacity_after - required_draws
+        if slack <= 0:
+            return 0.0
+        if slack >= buffer:
+            return 1.0
+        return slack / buffer
     
     def run_scenario_with_existing_game(self, game_id: str, scenario: int) -> Dict:
         """Run a complete game using an existing game ID"""
@@ -205,7 +197,7 @@ class BerghainBouncer:
                 current_counts, admitted_count
             )
             
-            accept = accept_prob > 0.5
+            accept = random.random() < accept_prob
             
             if accept:
                 admitted_count += 1


### PR DESCRIPTION
## Summary
- Add probabilistic slack-based acceptance to allow some non-contributing patrons while reserving expected capacity for constraints
- Use randomised decisions based on available slack and expected draws for remaining attributes

## Testing
- `pytest test_fixed_algorithm.py test_new_game.py test_running_games.py test_direct_api.py test_provided_games.py -q`
- `python -u final_test.py` *(rate limited after multiple runs; earlier scenario 1 completed with 878 rejections)*

------
https://chatgpt.com/codex/tasks/task_e_68ba661625708325b373d8d186a7c0f2