### PR TITLE
Improve bouncer acceptance slack

### DIFF
--- a/bouncer.py
+++ b/bouncer.py
@@ -158,7 +158,7 @@ class BerghainBouncer:
             constraints = [
                 {"attribute": "underground_veteran", "minCount": 500},
                 {"attribute": "international", "minCount": 650},
-                {"attribute": "fashion_dressed", "minCount": 550},
+                {"attribute": "fashion_forward", "minCount": 550},
                 {"attribute": "queer_friendly", "minCount": 250},
                 {"attribute": "vinyl_collector", "minCount": 200},
                 {"attribute": "german_speaker", "minCount": 800}
@@ -169,7 +169,7 @@ class BerghainBouncer:
                 "relativeFrequencies": {
                     "young": 0.502, "well_dressed": 0.601, "techno_lover": 0.651,
                     "well_connected": 0.451, "creative": 0.062, "berlin_local": 0.398,
-                    "underground_veteran": 0.501, "international": 0.651, "fashion_dressed": 0.551,
+                    "underground_veteran": 0.501, "international": 0.651, "fashion_forward": 0.551,
                     "queer_friendly": 0.251, "vinyl_collector": 0.201, "german_speaker": 0.4565
                 },
                 "correlations": {}
@@ -179,7 +179,7 @@ class BerghainBouncer:
                 "relativeFrequencies": {
                     "young": 0.502, "well_dressed": 0.601, "techno_lover": 0.651,
                     "well_connected": 0.451, "creative": 0.062, "berlin_local": 0.398,
-                    "underground_veteran": 0.501, "international": 0.651, "fashion_dressed": 0.551,
+                    "underground_veteran": 0.501, "international": 0.651, "fashion_forward": 0.551,
                     "queer_friendly": 0.251, "vinyl_collector": 0.201, "german_speaker": 0.4565
                 },
                 "correlations": {}
@@ -189,7 +189,7 @@ class BerghainBouncer:
                 "relativeFrequencies": {
                     "young": 0.502, "well_dressed": 0.601, "techno_lover": 0.651,
                     "well_connected": 0.451, "creative": 0.062, "berlin_local": 0.398,
-                    "underground_veteran": 0.501, "international": 0.651, "fashion_dressed": 0.551,
+                    "underground_veteran": 0.501, "international": 0.651, "fashion_forward": 0.551,
                     "queer_friendly": 0.251, "vinyl_collector": 0.201, "german_speaker": 0.4565
                 },
                 "correlations": {

--- a/bouncer.py
+++ b/bouncer.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import math
+import random
 from typing import Dict, List, Optional, Tuple
 
 class BerghainBouncer:
@@ -43,49 +44,93 @@ class BerghainBouncer:
         remaining_capacity = 1000 - admitted_count
         if remaining_capacity <= 0:
             return 0.0
-            
-        correlations = attribute_stats.get("correlations", {})
-        frequencies = attribute_stats["relativeFrequencies"]
-        
-        total_value = 0.0
-        constraint_satisfaction = 0.0
-        
-        for constraint in constraints:
-            attr = constraint["attribute"]
-            min_count = constraint["minCount"]
-            current_count = current_counts.get(attr, 0)
-            remaining_needed = max(0, min_count - current_count)
-            
-            if person_attributes.get(attr, False):
-                constraint_satisfaction += 1
-                
-                if remaining_needed > 0:
-                    attr_frequency = frequencies[attr]
-                    expected_future_with_attr = remaining_capacity * attr_frequency
-                    
-                    urgency = remaining_needed / max(1, expected_future_with_attr)
-                    
-                    correlation_bonus = 0.0
-                    for other_attr, has_other in person_attributes.items():
-                        if has_other and other_attr != attr and other_attr in correlations.get(attr, {}):
-                            correlation_value = correlations[attr][other_attr]
-                            if correlation_value > 0:
-                                correlation_bonus += correlation_value * 0.1
-                    
-                    total_value += urgency * (1 + correlation_bonus)
-        
-        progress_ratio = admitted_count / 1000.0
-        if progress_ratio < 0.3:
-            threshold_modifier = 0.8
-        elif progress_ratio < 0.7:
-            threshold_modifier = 1.0
-        else:
-            threshold_modifier = 1.2
-            
-        if constraint_satisfaction > 0:
-            return min(1.0, (total_value / constraint_satisfaction) * threshold_modifier)
-        else:
-            return 0.1
+        # If all constraints are already satisfied, admit everyone else to avoid
+        # unnecessary rejections and fill the club efficiently.
+        shortages = {
+            c["attribute"]: max(0, c["minCount"] - current_counts.get(c["attribute"], 0))
+            for c in constraints
+        }
+
+        if all(v == 0 for v in shortages.values()):
+            return 1.0
+
+        # Accept anyone who contributes to an unmet constraint
+        for attr, shortage in shortages.items():
+            if shortage > 0 and person_attributes.get(attr, False):
+                return 1.0
+
+        # Person doesn't help meet unmet constraints; decide based on expected availability
+        remaining_capacity_after = remaining_capacity - 1
+        if remaining_capacity_after <= 0:
+            return 0.0
+
+        freq = attribute_stats.get("relativeFrequencies", {})
+        required_draws = 0.0
+        for attr, shortage in shortages.items():
+            p = freq.get(attr, 0.01)
+            required_draws = max(required_draws, shortage / p)
+
+        buffer = 15  # keep some spare capacity beyond expected needs
+        slack = remaining_capacity_after - required_draws
+        if slack <= 0:
+            return 0.0
+        if slack >= buffer:
+            return 1.0
+        return slack / buffer
+
+    def _should_accept_scenario2(
+        self,
+        person_attributes: Dict[str, bool],
+        constraints: List[Dict],
+        current_counts: Dict[str, int],
+        admitted_count: int,
+    ) -> bool:
+        """Specialized decision logic for scenario 2.
+
+        Prioritizes creative and berlin_local attributes while ensuring we
+        do not exceed the maximum number of non-locals that can be admitted
+        (250 when 750 berlin locals are required). The method greedily accepts
+        people who help satisfy still-missing constraints and rejects others.
+        """
+
+        needed = {c["attribute"]: c["minCount"] for c in constraints}
+
+        is_local = person_attributes.get("berlin_local", False)
+        is_creative = person_attributes.get("creative", False)
+        is_techno = person_attributes.get("techno_lover", False)
+        is_connected = person_attributes.get("well_connected", False)
+
+        current_locals = current_counts.get("berlin_local", 0)
+        current_creatives = current_counts.get("creative", 0)
+        current_techno = current_counts.get("techno_lover", 0)
+        current_connected = current_counts.get("well_connected", 0)
+
+        max_non_local = 1000 - needed.get("berlin_local", 0)
+        non_local_admitted = admitted_count - current_locals
+
+        # Stage 1: we still need more creatives
+        if current_creatives < needed.get("creative", 0):
+            if is_creative and (is_local or non_local_admitted < max_non_local):
+                return True
+            return False
+
+        # Stage 2: creative target met, now fill berlin locals
+        if current_locals < needed.get("berlin_local", 0):
+            if is_local:
+                return True
+            return False
+
+        # Stage 3: satisfy remaining techno_lover and well_connected counts
+        if current_techno < needed.get("techno_lover", 0) and is_techno:
+            return True
+        if current_connected < needed.get("well_connected", 0) and is_connected:
+            return True
+
+        # Once all constraints satisfied, accept everyone
+        if all(current_counts[attr] >= need for attr, need in needed.items()):
+            return True
+
+        return False
     
     def run_scenario_with_existing_game(self, game_id: str, scenario: int) -> Dict:
         """Run a complete game using an existing game ID"""
@@ -200,12 +245,16 @@ class BerghainBouncer:
             person_attributes = person["attributes"]
             current_person_index = person["personIndex"]
             
-            accept_prob = self.calculate_acceptance_probability(
-                person_attributes, constraints, attribute_stats, 
-                current_counts, admitted_count
-            )
-            
-            accept = accept_prob > 0.5
+            if scenario == 2:
+                accept = self._should_accept_scenario2(
+                    person_attributes, constraints, current_counts, admitted_count
+                )
+            else:
+                accept_prob = self.calculate_acceptance_probability(
+                    person_attributes, constraints, attribute_stats,
+                    current_counts, admitted_count
+                )
+                accept = random.random() < accept_prob
             
             if accept:
                 admitted_count += 1

--- a/scenario3_optimized.py
+++ b/scenario3_optimized.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Run scenario 3 with a strategy tuned to minimise rejections.
+
+The default `bouncer.py` implementation uses a generic heuristic for
+scenarios 1 and 3.  This script focuses solely on scenario 3 and applies
+custom logic that aggressively fills required attribute quotas while
+keeping the number of rejected entrants as low as possible.  It makes a
+single game request and then only the minimal `decide-and-next` calls
+necessary to complete the scenario, helping avoid rate‑limit issues.
+"""
+
+from typing import Dict
+
+from bouncer import BerghainBouncer
+
+
+class Scenario3Bouncer(BerghainBouncer):
+    """Specialised bouncer with acceptance rules for scenario 3."""
+
+    def _should_accept(
+        self, attrs: Dict[str, bool], current: Dict[str, int], admitted: int
+    ) -> bool:
+        """Return ``True`` if admitting this person keeps all constraints feasible.
+
+        Rather than working in stages, the algorithm checks whether accepting
+        the current person would still leave enough capacity to satisfy all
+        outstanding attribute requirements.  If doing so would make it
+        impossible to meet the remaining quotas, the person is rejected;
+        otherwise they are admitted.  This accepts as many entrants as
+        possible early on, minimising unnecessary rejections.
+        """
+
+        needed = {
+            "underground_veteran": 500,
+            "international": 650,
+            "fashion_forward": 550,
+            "queer_friendly": 250,
+            "vinyl_collector": 200,
+            "german_speaker": 800,
+        }
+
+        capacity = 1000
+        remaining_capacity = capacity - admitted
+        if remaining_capacity <= 0:
+            return False
+
+        # Simulate admitting this person and see how many slots would still be
+        # required to satisfy the remaining quotas.
+        future_counts = current.copy()
+        for attr, has in attrs.items():
+            if has and attr in future_counts:
+                future_counts[attr] += 1
+
+        deficits = {
+            attr: max(0, needed[attr] - future_counts[attr]) for attr in needed
+        }
+
+        # If any single attribute would require more people than we have slots
+        # left after admitting this person, we must reject them.
+        if any(deficit > (remaining_capacity - 1) for deficit in deficits.values()):
+            return False
+
+        return True
+
+    def run(self, existing_game_id: str | None = None) -> Dict:
+        """Play through scenario 3 and return final statistics.
+
+        If ``existing_game_id`` is provided, a new game is not created and the
+        provided ID is used instead.  This helps minimise the number of API
+        calls when reusing a pre-generated blank game.
+        """
+
+        if existing_game_id is None:
+            game = self.create_game(3)
+            game_id = game["gameId"]
+            constraints = game["constraints"]
+            result = self.make_decision(game_id, 0)
+        else:
+            game_id = existing_game_id
+            result = self.make_decision(game_id, 0)
+            constraints = result.get("constraints")
+            if constraints is None:
+                constraints = [
+                    {"attribute": "underground_veteran", "minCount": 500},
+                    {"attribute": "international", "minCount": 650},
+                    {"attribute": "fashion_forward", "minCount": 550},
+                    {"attribute": "queer_friendly", "minCount": 250},
+                    {"attribute": "vinyl_collector", "minCount": 200},
+                    {"attribute": "german_speaker", "minCount": 800},
+                ]
+
+        counts = {c["attribute"]: 0 for c in constraints}
+        admitted = 0
+        rejected = 0
+
+        while result.get("status") == "running":
+            person = result["nextPerson"]
+            attrs = person["attributes"]
+            index = person["personIndex"]
+
+            accept = self._should_accept(attrs, counts, admitted)
+
+            if accept:
+                admitted += 1
+                for attr, has in attrs.items():
+                    if has and attr in counts:
+                        counts[attr] += 1
+            else:
+                rejected += 1
+
+            result = self.make_decision(game_id, index, accept)
+
+        return {
+            "status": result.get("status", "unknown"),
+            "rejected_count": result.get("rejectedCount", rejected),
+            "admitted_count": admitted,
+            "final_counts": counts,
+        }
+
+
+def main() -> None:
+    bouncer = Scenario3Bouncer()
+    outcome = bouncer.run()
+    print(
+        f"Scenario 3 finished with status {outcome['status']}\n"
+        f"Admitted: {outcome['admitted_count']}  "
+        f"Rejected: {outcome['rejected_count']}\n"
+        f"Final counts: {outcome['final_counts']}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Merge in upstream branch to resolve conflicts and keep slack-based acceptance probability
- Integrate specialized scenario 2 logic while using probabilistic admission for other scenarios

## Testing
- `pytest test_fixed_algorithm.py test_new_game.py test_running_games.py test_direct_api.py test_provided_games.py -q`
- `python -u final_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba661625708325b373d8d186a7c0f2